### PR TITLE
Initial Documentation Infrastructure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_DOMAIN: sandag.github.io/rsm
+          CONFIG_FILE: mkdocs.yml
+          EXTRA_PACKAGES: build-base
+          REQUIREMENTS: docs_requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _version.py
 .DS_Store
 test/data/*
 *.pyc
+sandag_rsm.egg-info/*
+site/*

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Instructions for Editing/Managing Documentation
+
+TODO: update/refine as needed
+
+## Getting Started
+
+To get started using Anaconda, do the following:
+
+```
+conda create -n rsm_docs python=3.10
+conda activate rsm_docs
+pip install -r docs_requirements.txt
+```
+
+To create the website locally:
+
+```
+mkdocs serve
+```
+
+See the `mkdocs.yml` file for the configuration.
+
+To create the website on GitHub pages, see the .github/workflows/docs.yml

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,12 @@
+# Application Programming Interface
+
+::: rsm.assembler
+::: rsm.input_agg
+::: rsm.poi
+::: rsm.sampler
+::: rsm.translate
+::: rsm.utility
+::: rsm.zone_agg
+::: rsm.data_load.skims
+::: rsm.data_load.triplist
+::: rsm.data_load.zones

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,3 @@
+# Design
+
+TODO: document the model design here

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,0 +1,9 @@
+# SANDAG Rapid Strategic Model
+
+TODO: Add Welcome and navigation here
+
+[Model Design](design.md)
+
+[Application Programming Interface](api.md)
+
+Examples -- TODO: create example notebooks you want to include in the documentation in the docs folder, add navigation to them in mkdocs.yml

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,0 +1,15 @@
+fontawesome_markdown
+json5
+jsonschema
+Markdown
+markdown-it-py
+mike
+mkdocs
+mkdocs-autorefs
+mkdocs-awesome-pages-plugin
+mkdocs-jupyter
+mkdocs-material
+mkdocs-material-extensions
+mkdocstrings
+mkdocstrings-python
+mkdocs-table-reader-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,77 @@
+site_name: "SANDAG Rapid Strategic Model"
+site_url: https://sandag.github.io/rsm
+repo_url: https://github.com/SANDAG/RSM
+
+use_directory_urls: false
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - content.code.annotate
+    - content.tabs.link
+    - navigation.indexes
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: deep orange
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: grey
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
+
+plugins:
+  - autorefs
+  - awesome-pages
+  - mike
+  - mkdocs-jupyter:
+      include_source: True
+  - mkdocstrings:
+      default_handler: python
+      enable_inventory: true
+      handlers:
+          rendering:
+            show_root_heading: false
+            show_source: true
+            heading_level: 3
+      custom_templates: templates
+  - search
+  - table-reader
+
+nav:
+  - Home: home.md
+  - Design: design.md
+  - API: api.md
+
+extra:
+  version:
+    provider: mike
+    default: latest
+
+extra_css:
+  - https://use.fontawesome.com/releases/v5.13.0/css/all.css
+
+markdown_extensions:
+  - admonition
+  - codehilite:
+      linenums: true
+  - fontawesome_markdown
+  - meta
+  - pymdownx.inlinehilite
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.smartsymbols
+  - smarty
+  - tables
+  - toc:
+      # insert a blank space before the character
+      permalink: " ¶"


### PR DESCRIPTION
@JoeJimFlood
To enable the publishing of the documentation via GitHub pages, you need to:

1. In the repository, go to Settings -> Pages.
2. In the Branch dropdown, select `gh-pages`

You can then update the `About` section of the repository to include the URL for the documentation.

I'll merge this now to trigger the GitHub Action, which *should* create the `gh-pages` branch. This will allow you to select the `gh-pages` branch in the settings.

@AshishKuls: after the merge, I'll create another branch that Lawrence can use to update the documentation. See the `README` in the `docs` folder for instructions on how to set things up and run them locally.  